### PR TITLE
chore: Remove GitHub token from docker action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,8 +20,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - uses: cardinalby/export-env-action@v2
         with:


### PR DESCRIPTION
### What
- Hopefully the toke isn't needed anymore
