### PR TITLE
ci: Build linux/arm64 and linux/amd64 images

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -62,7 +62,7 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
           cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels
+          labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           build-args:
             KEYCLOAK_VERSION=${{ env.KEYCLOAK_VERSION }}

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -62,6 +62,7 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
           cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          labels: ${{ steps.meta.outputs.labels
+          platforms: linux/amd64,linux/arm64
           build-args:
             KEYCLOAK_VERSION=${{ env.KEYCLOAK_VERSION }}


### PR DESCRIPTION
### What
- Update the container build process to build ARM64 images in addition to AMD64 images.

### Screenshot
N/A

### Fixes bug(s)
- https://openfoodfacts.slack.com/archives/C02LDQDDD/p1750672112559859

### Part of 
N/A
