### PR TITLE
fix: Use make to start services so that .env is used

### DIFF
--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -161,7 +161,7 @@ jobs:
         proxy_key: ${{ secrets.SSH_PRIVATE_KEY }}
         script: |
             cd ${{ matrix.env }}
-            docker compose up --wait --wait-timeout 300
+            make _up
 
     - name: Cleanup obsolete Docker objects
       uses: appleboy/ssh-action@master


### PR DESCRIPTION
Signed-off-by: John Gomersall <thegoms@gmail.com>

### What
- Use make to start services so that .env is used
