### PR TITLE
fix: Should build the test image before running Playwright actions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install dependencies
       run: make init
     - name: Build
-      run: make build
+      run: make build_test
     - name: Run Playwright tests
       run: make test
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install dependencies
         run: make init
       - name: Build
-        run: make build
+        run: make build_test
       - name: Update Playwright test results
         run: make update_screenshots
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Signed-off-by: John Gomersall <thegoms@gmail.com>

### What
- Playwright use the testcontainer image. Need to build this locally as otherwise the one from the last push to main will be used