### PR TITLE
chore: Use original action-wait-for-check so does not fail if job not created yet

### DIFF
--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -47,12 +47,12 @@ jobs:
         echo "KEYCLOAK_STARTUP=prod" >> $GITHUB_ENV
 
     - name: Wait for container build workflow
-      uses: tomchv/wait-my-workflow@v1.1.0
+      uses: fountainhead/action-wait-for-check@v1.2.0
       id: wait-build
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         checkName: push-images
-        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+        ref: ${{ github.sha }}
         intervalSeconds: 10
         timeoutSeconds: 1800 # 30m
 


### PR DESCRIPTION
Signed-off-by: John Gomersall <thegoms@gmail.com>

### What
- Previous wait for check action was stopping if the job hadn't yet been created
