### PR TITLE
feat: Include name in standard profile

### DIFF
--- a/runtime-scripts/after_startup.sh
+++ b/runtime-scripts/after_startup.sh
@@ -83,6 +83,10 @@ else
   echo "$(date -u) *** Configuring user profiles ***"
   /opt/keycloak/bin/kcadm.sh update users/profile -r openfoodfacts -f /opt/off/users_profile.json
 
+  # Include name in standard access token
+  echo "$(date -u) *** Adding name to token profile [ignore duplicate errors] ***"
+  /opt/keycloak/bin/kcadm.sh create client-scopes/e100d014-3f1d-4075-9777-643deeda8811/protocol-mappers/add-models -r openfoodfacts -f /opt/off/name_profile.json
+
   cp /opt/off/image_id ~/off/deployed_image_id
 fi
 

--- a/runtime-scripts/name_profile.json
+++ b/runtime-scripts/name_profile.json
@@ -1,0 +1,19 @@
+[
+  {
+    "id": "d0d4e698-c0e3-461d-aa0d-d18e5ee78ee2",
+    "name": "name",
+    "protocol": "openid-connect",
+    "protocolMapper": "oidc-usermodel-attribute-mapper",
+    "consentRequired": false,
+    "config": {
+      "introspection.token.claim": "true",
+      "userinfo.token.claim": "true",
+      "user.attribute": "name",
+      "id.token.claim": "true",
+      "lightweight.claim": "false",
+      "access.token.claim": "true",
+      "claim.name": "name",
+      "jsonType.label": "String"
+    }
+  }
+]

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -133,6 +133,7 @@ test("pkce login works", async ({ page }) => {
   // Login should occur on the verify page.
   // Behavior on the original page is a bit unpredictable at the moment
   await expect(verifyPage.getByLabel('preferred_username')).toHaveValue(userName);
+  await expect(verifyPage.getByLabel('name', {exact: true})).toHaveValue(`Test User ${userName}`);
   await expect(verifyPage.getByLabel('azp')).toHaveValue('test_public_client');
   expect(verifyPage.url()).toContain('lang=xx');
   

--- a/tests/test-helper.ts
+++ b/tests/test-helper.ts
@@ -125,6 +125,7 @@ export async function populateRegistrationForm(page: Page, allFields = false) {
 
 async function fillRegistrationForm(page, userName, password, email, allFields) {
   await page.getByLabel('^username^').fill(userName);
+  await page.getByLabel('^name^').fill(`Test User ${userName}`);
   await page.getByRole('textbox', { name: '^password^', exact: true }).fill(password);
   await page.getByLabel('^passwordConfirm^').fill(password);
   await page.getByLabel('^email^').fill(email);


### PR DESCRIPTION
Signed-off-by: John Gomersall <thegoms@gmail.com>

### What
Product Opener is expecting the user's name (full name, not just user id) to be in the token. Adding this to the standard profile
