### PR TITLE
fix(deps): Update Keycloak version to 26.5.7

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # Please see the README.m for details on steps to be taken when updating Keycloak
-KEYCLOAK_VERSION=26.3.0
+KEYCLOAK_VERSION=26.5.7
 
 # These is the master realm administrator account
 KC_BOOTSTRAP_ADMIN_USERNAME=root

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN --mount=type=cache,target=/root/.m2 set -x && \
     export SKIP_INTEGRATION_TESTS=true && \
     mvn -B package
 
-FROM quay.io/keycloak/keycloak:26.5.6 AS base
+FROM quay.io/keycloak/keycloak:26.5.7 AS base
 # Base image that the test and production images derive from.
 # Note the version number above is set by the update_keycloak_version.mjs script, so no need to edit manually
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <name>ProductOpener Keycloak extensions</name>
   <groupId>openfoodfacts.github.keycloak</groupId>
   <artifactId>keycloak-extensions</artifactId>
-  <version>26.5.6</version>
+  <version>26.5.7</version>
   <packaging>jar</packaging>
   <properties>
     <java.version>21</java.version>
@@ -15,10 +15,10 @@
     <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
     <maven-site-plugin.version>4.0.0-M16</maven-site-plugin.version>
     <maven-assembly-plugin.version>3.8.0</maven-assembly-plugin.version>
-    <revision>26.5.6</revision>
+    <revision>26.5.7</revision>
     <changelist>-SNAPSHOT</changelist>
     <sha1/>
-    <keycloak.version>26.5.6</keycloak.version>
+    <keycloak.version>26.5.7</keycloak.version>
     <junit.version>6.0.3</junit.version>
   </properties>
   <build>


### PR DESCRIPTION
### What

Bump Keycloak version from 26.5.6 to 26.5.7 to fix CVEs: https://www.keycloak.org/2026/04/keycloak-2657-released

### Screenshot

No UI updates necessary

### Fixes bug(s)

N/A