### PR TITLE
ci: Update checkName for deployment job

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -113,6 +113,10 @@ jobs:
 
   # Only runs on push to main. Does the full multi-platform build (using above image to cache the linux/amd64 one)
   # and pushes the images to the registry
+  #
+  # ⚠️ The job name is referenced by container-deploy.yml via fountainhead/action-wait-for-check.
+  # The matrix strategy adds matrix values in parentheses, e.g. "push-images (regular)".
+  # If renaming or restructuring this job, update the check name in container-deploy.yml accordingly.
   push-images:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest

--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -52,7 +52,7 @@ jobs:
       id: wait-build
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        checkName: push-images
+        checkName: push-images (regular)
         ref: ${{ github.sha }}
         intervalSeconds: 30
         timeoutSeconds: 2400 # 40m


### PR DESCRIPTION
### What

This pull request makes a small but important update to the container deployment workflow to ensure it correctly waits for the appropriate build job. The change aligns the check name in the deployment workflow with the actual name used in the build workflow, accounting for the matrix strategy that appends values in parentheses.

Workflow coordination:

* Updated the `checkName` in `container-deploy.yml` to `push-images (regular)` to match the matrix job name produced by the build workflow.
* Added clarifying comments in `container-build.yml` explaining the job naming convention and the dependency with `container-deploy.yml`, to prevent future mismatches if the job is renamed or restructured.

### Screenshot

N/A

### Fixes bug(s)

https://github.com/openfoodfacts/openfoodfacts-auth/actions/runs/26692649670/job/78676188479

### Part of 

N/A